### PR TITLE
restore ReconfigureLeafCmd function

### DIFF
--- a/misc.go
+++ b/misc.go
@@ -18,7 +18,7 @@ func VisitCommands(cmd *cobra.Command, fns ...ReconfigureFunc) {
 	}
 }
 
-func ReconfigureLeafCmds(fs ...func(cmd *cobra.Command)) ReconfigureFunc {
+func ReconfigureLeafCmd(fs ...func(cmd *cobra.Command)) ReconfigureFunc {
 	return func(cmd *cobra.Command) {
 		if len(cmd.Commands()) > 0 {
 			return


### PR DESCRIPTION
Signed-off-by: Paul Czarkowski <username.taken@gmail.com>

I'm unsure of the need for ReconfigureLeafCmd  being renamed to ReconfigureLeafCmds, but it broke a bunch of deps for me, this restores the functionality that I needed.

fixes #2 