### PR TITLE
Use cmd.Name() instead of cmd.Use to format help sections

### DIFF
--- a/misc.go
+++ b/misc.go
@@ -64,7 +64,7 @@ func ReconfigureCmdWithSubcmd(cmd *cobra.Command) {
 	var strs []string
 	for _, subcmd := range cmd.Commands() {
 		if !subcmd.Hidden {
-			strs = append(strs, subcmd.Use)
+			strs = append(strs, subcmd.Name())
 		}
 	}
 
@@ -87,7 +87,7 @@ func ShowSubcommands(cmd *cobra.Command, args []string) error {
 	var strs []string
 	for _, subcmd := range cmd.Commands() {
 		if !subcmd.Hidden {
-			strs = append(strs, subcmd.Use)
+			strs = append(strs, subcmd.Name())
 		}
 	}
 	return fmt.Errorf("Use one of available subcommands: %s", strings.Join(strs, ", "))


### PR DESCRIPTION
cmd.Use causes the help section to become less readable in case of positional args, hence use cmd.Name() instead