### PR TITLE
IsCobraInternalCommand -> IsCobraManagedCommand

### DIFF
--- a/misc.go
+++ b/misc.go
@@ -98,7 +98,7 @@ func ShowHelp(cmd *cobra.Command, args []string) error {
 	return fmt.Errorf("Invalid command - see available commands/subcommands above")
 }
 
-func IsCobraInternalCommand(args []string) bool {
+func IsCobraManagedCommand(args []string) bool {
 	if len(args) > 1 {
 		cmdPathPieces := args[1:]
 


### PR DESCRIPTION
Rename `IsCobraInternalCommand` to `IsCobraManagedCommand`.

This would be a breaking change for anyone using this and bumping the version, but it is used only in kapp and kctrl and we should be able to make the change when we would want to bump cobrautil.

More details on why this change is being made can be found [here](https://github.com/vmware-tanzu/carvel-imgpkg/pull/432#issuecomment-1249485017).

cc @cppforlife 