### PR TITLE
Hard-code the original Cobra help template

### DIFF
--- a/help_sections.go
+++ b/help_sections.go
@@ -30,17 +30,35 @@ type HelpSection struct {
 }
 
 func HelpSectionsUsageTemplate(sections []HelpSection) string {
-	unmodifiedCmd := &cobra.Command{}
-	usageTemplate := unmodifiedCmd.UsageTemplate()
+	usageTemplate := `Usage:{{if .Runnable}}
+  {{.UseLine}}{{end}}{{if .HasAvailableSubCommands}}
+  {{.CommandPath}} [command]{{end}}{{if gt (len .Aliases) 0}}
+
+Aliases:
+  {{.NameAndAliases}}{{end}}{{if .HasExample}}
+
+Examples:
+{{.Example}}{{end}}{{if .HasAvailableSubCommands}}
+
+Available Commands:{{range .Commands}}{{if (or .IsAvailableCommand (eq .Name "help"))}}
+  {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{end}}{{if .HasAvailableLocalFlags}}
+
+Flags:
+{{.LocalFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}{{if .HasAvailableInheritedFlags}}
+
+Global Flags:
+{{.InheritedFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}{{if .HasHelpSubCommands}}
+
+Additional help topics:{{range .Commands}}{{if .IsAdditionalHelpTopicCommand}}
+  {{rpad .CommandPath .CommandPathPadding}} {{.Short}}{{end}}{{end}}{{end}}{{if .HasAvailableSubCommands}}
+
+Use "{{.CommandPath}} [command] --help" for more information about a command.{{end}}
+`
 
 	const defaultTpl = `{{if .HasAvailableSubCommands}}
 
 Available Commands:{{range .Commands}}{{if (or .IsAvailableCommand (eq .Name "help"))}}
   {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{end}}`
-
-	if !strings.Contains(usageTemplate, defaultTpl) {
-		panic("Expected to find available commands section in spf13/cobra default usage template")
-	}
 
 	newTpl := "{{if .HasAvailableSubCommands}}"
 


### PR DESCRIPTION
Fixes #7 

Cobra 1.6 has modified the default help template to support grouping. This breaks the logic in cobrautil which manipulates that help string.

This commit hard-codes the original cobra help string instead of obtaining it from Cobra.  This allows cobrautil to continue working as before for older versions of Cobra or newer ones.
